### PR TITLE
Added endpoint to give an arbitrary number of random recipes

### DIFF
--- a/Schema/recipe.js
+++ b/Schema/recipe.js
@@ -32,19 +32,6 @@ RecipeSchema.pre('save', function(next) {
   next();
 });
 
-/**
- * Return a random recipe
- */
-RecipeSchema.statics.random = function(callback) {
-  this.estimatedDocumentCount(function(err, count) {
-    if (err) {
-      return callback(err);
-    }
-    const rand = Math.floor(Math.random() * count);
-    this.findOne().skip(rand).exec(callback);
-  }.bind(this));
-};
-
 var Recipe = mongoose.model('Recipe', RecipeSchema);
 
 module.exports = Recipe;

--- a/routes/recipes.js
+++ b/routes/recipes.js
@@ -81,15 +81,20 @@ router.post('/recipes', upload, (req,res) => {
 });
 
 router.get('/random', (req, res) => {
-  console.log("Fetching random recipe")
+  res.redirect('/random/1')
+})
+
+router.get('/random/:number', (req, res) => {
+  console.log("Fetching random recipes")
   
-  Recipe.random(function(err, recipe) {
+  const numberOfRecipes = parseInt(req.params.number, 10);
+
+  Recipe.aggregate([{ $sample: { size: numberOfRecipes } }], (err, result) => {
     if (err) {
       res.sendStatus(500)
-      return
+    } else {
+      res.json(result);
     }
-    // object of the user
-    res.json(recipe)
   });
 })
 


### PR DESCRIPTION
This PR updates the /random endpoint to use a more native method of choosing random recipes and adds /random/:number which simplifies getting N random recipes