### PR TITLE
Improved image storage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,9 @@
-node_modules
+.dockerignore
 .env
+.git
 .gitignore
-README.md
 Dockerfile
+node_modules
+public
+README.md
+tmp/images/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV DATABASE_HOST 'mongodb://localhost'
 ENV DATABASE_NAME recipes
 ENV DATABASE_USER ""
 ENV DATABASE_PW ""
+ENV IMAGE_DIR 'public/images'
 
 WORKDIR /app
 

--- a/Schema/image.js
+++ b/Schema/image.js
@@ -3,7 +3,7 @@ var Schema = mongoose.Schema
 
 var ImageSchema = new Schema(
   {
-    path: { type: String, required: true }
+    name: { type: String, required: true }
   },
   {
     timestamps: true

--- a/Schema/recipe.js
+++ b/Schema/recipe.js
@@ -6,7 +6,7 @@ var Image = require('./image')
 var RecipeSchema = new Schema(
   {
     name: { type: String, required: true, unique: true },
-    image: Image,
+    images: [Image],
     sourceName: String,
     sourceUrl: String,
     ingredients: [Ingredient],

--- a/app.js
+++ b/app.js
@@ -33,8 +33,9 @@ const randomRouter = require('./routes/random.js')
 app.use('/random', randomRouter)
 
 var path = require('path')
-app.use('/public/images', express.static(path.join(__dirname, '/public/images')))
+app.use('/public/images', express.static(path.join(__dirname, process.env.IMAGE_DIR)))
 
 app.listen(process.env.PORT, () => {
+  console.log('images in ' + process.env.IMAGE_DIR)
   console.log('server is now up')
 })


### PR DESCRIPTION
Add: images now served through REST interface
Add: Recipe schema now take multiple images
Add: image files now stored grouped by recipe
Add: can now upload image separately to recipe
Add: can now delete image without updating entire recipe
Fix: copy and delete files rather than renaming for better docker support
Add: made image directory configurable
Add: improved .dockerignore